### PR TITLE
changing docker repo to KPN official

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BUILD_DIR ?= build
 GOCMD=go
 GOBUILD=$(GOCMD) build
 GOTEST=$(GOCMD) test
-DOCKER_IMAGE=kpnnv/mq-hammer
+DOCKER_IMAGE=kpnnl/mq-hammer
 
 # get version info from git's tags
 GIT_COMMIT := $(shell git rev-parse HEAD)

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ One application of MQ Hammer is load testing. Another possible application is to
 
 Binaries for Linux and macOS are available from the [releases](https://github.com/kpn/mq-hammer/releases/) page.
 
-A docker image is available on [dockerhub](https://hub.docker.com/r/kpnnv/mq-hammer), e.g.:
+A docker image is available on [dockerhub](https://hub.docker.com/r/kpnnl/mq-hammer), e.g.:
 
-    docker run -it kpnnv/mq-hammer version
+    docker run -it kpnnl/mq-hammer version
 
 For manual building, assuming a working Go environment and `dep` installed:
 


### PR DESCRIPTION
Docker announced to sunsetting the Free Tier dockerhub. Although the withdrawn this action, we still like to point all links to our official KPN Business Tier Docker repo. 